### PR TITLE
Fix possible duplicate shorty exception

### DIFF
--- a/src/main/java/nl/joelchrist/shorty/shorties/endpoints/ShortiesEndpoint.java
+++ b/src/main/java/nl/joelchrist/shorty/shorties/endpoints/ShortiesEndpoint.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 @RestController
 @CrossOrigin()
 public class ShortiesEndpoint {
-    static Logger log = Logger.getLogger(ShortiesEndpoint.class.getName());
+    private static Logger log = Logger.getLogger(ShortiesEndpoint.class.getName());
 
     @Autowired
     private ShortiesManager shortiesManager;

--- a/src/main/java/nl/joelchrist/shorty/shorties/managers/ShortiesManager.java
+++ b/src/main/java/nl/joelchrist/shorty/shorties/managers/ShortiesManager.java
@@ -20,7 +20,10 @@ public class ShortiesManager {
     private ShortiesRepository shortiesRepository;
 
     public Shorty createShorty(String fullUrl) {
-        String shortIdentifier = shortyUtil.generateShortIdentifier();
+        String shortIdentifier;
+        do {
+            shortIdentifier = shortyUtil.generateShortIdentifier();
+        } while (shortiesRepository.findShorty(shortIdentifier).isPresent());
         Shorty shorty = new Shorty(fullUrl, shortIdentifier);
         return createShorty(shorty);
     }


### PR DESCRIPTION
This would occur if the random shorty creation method would come up with a short identifier that already existed.